### PR TITLE
Add kernel tracing.

### DIFF
--- a/examples/tracer-kernel/Makefile
+++ b/examples/tracer-kernel/Makefile
@@ -1,0 +1,7 @@
+SHELL := /bin/bash
+
+all: build
+
+build: main.go
+	source ../../build/vars.sh && \
+		go build .

--- a/examples/tracer-kernel/main.go
+++ b/examples/tracer-kernel/main.go
@@ -1,0 +1,74 @@
+//go:build windows
+// +build windows
+
+package main
+
+import (
+	"encoding/json"
+	"flag"
+	"log"
+	"os"
+	"os/signal"
+	"sync"
+
+	"github.com/Velocidex/etw"
+)
+
+func main() {
+	var ()
+	flag.Parse()
+
+	session, err := etw.NewKernelSession(etw.WithKernelKeyword("FileIOInit"))
+	if err != nil {
+		log.Fatalf("Failed to create etw session; %s", err)
+	}
+
+	enc := json.NewEncoder(os.Stdout)
+	enc.SetIndent("", "  ")
+	cb := func(e *etw.Event) {
+		log.Printf("[DBG] Event %d from %s\n", e.Header.ID, e.Header.TimeStamp)
+
+		event := make(map[string]interface{})
+
+		if data, err := e.EventProperties(); err == nil {
+			event["EventProperties"] = data
+		} else {
+			log.Printf("[ERR] Failed to enumerate event properties: %s", err)
+		}
+		_ = enc.Encode(event)
+	}
+
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go func() {
+		log.Println("[DBG] Starting to listen kernel ETW")
+
+		// Block until .Close().
+		if err := session.Process(cb); err != nil {
+			log.Printf("[ERR] Got error processing events: %s", err)
+		} else {
+			log.Printf("[DBG] Successfully shut down")
+		}
+
+		wg.Done()
+	}()
+
+	// Trap cancellation (the only signal values guaranteed to be present in
+	// the os package on all systems are os.Interrupt and os.Kill).
+	sigCh := make(chan os.Signal, 1)
+	signal.Notify(sigCh, os.Interrupt)
+
+	// Wait for stop and shutdown gracefully.
+	for range sigCh {
+		log.Printf("[DBG] Shutting the session down")
+
+		err = session.Close()
+		if err != nil {
+			log.Printf("[ERR] (!!!) Failed to stop session: %s\n", err)
+		} else {
+			break
+		}
+	}
+
+	wg.Wait()
+}

--- a/options.go
+++ b/options.go
@@ -1,4 +1,7 @@
-//+build windows
+//go:build windows
+// +build windows
+
+// Kernel session - credit to https://github.com/zdandoh/etw. Small modifications by zaneGittins.
 
 package etw
 
@@ -55,6 +58,9 @@ type SessionOptions struct {
 	// original API reference:
 	// https://docs.microsoft.com/en-us/windows/win32/api/evntrace/ns-evntrace-enable_trace_parameters
 	EnableProperties []EnableProperty
+
+	kernelSession     bool
+	KernelEnableFlags uint64
 }
 
 // Option is any function that modifies SessionOptions. Options will be called
@@ -69,6 +75,32 @@ func WithName(name string) Option {
 	return func(cfg *SessionOptions) {
 		cfg.Name = name
 	}
+}
+
+func withKernelSession() Option {
+	return func(cfg *SessionOptions) {
+		cfg.kernelSession = true
+	}
+}
+
+func WithKernelEnableFlags(flags uint64) Option {
+	return func(cfg *SessionOptions) {
+		cfg.KernelEnableFlags = flags
+	}
+}
+
+func WithKernelKeyword(keyword string) Option {
+
+	if val, ok := KernelKeywords[keyword]; ok {
+		return func(cfg *SessionOptions) {
+			cfg.KernelEnableFlags = val
+		}
+	} else {
+		return func(cfg *SessionOptions) {
+			cfg.KernelEnableFlags = 0
+		}
+	}
+
 }
 
 // WithLevel specifies a maximum level consumer is interested in. Higher levels


### PR DESCRIPTION
Pull request to add kernel tracing to velocidex/etw. Credit mostly goes to https://github.com/zdandoh/etw, however I made some small changes and additions.